### PR TITLE
now user can differentiate between modes

### DIFF
--- a/src/engine/controller.py
+++ b/src/engine/controller.py
@@ -78,7 +78,7 @@ class Controller:
 
         self.supportedRequests[requestType](request)
 
-    def updateTimer(self, time: str, percent: int):
+    def updateTimer(self, time: str, percent: int, mode: str) -> None:
         """Sends the updated time
         Using the pubsub method
         parameters:
@@ -89,6 +89,7 @@ class Controller:
              'topic': 'updateTimer',
              'elapsedTime': time,
              'percent': percent,
+             'mode': mode,
                 }
         pub.sendMessage('sendPubsub', message=message)
 

--- a/src/engine/session.py
+++ b/src/engine/session.py
@@ -49,7 +49,8 @@ class Session:
             breakTime = self.longBreakTime
 
         for elapsedTime, percentage in Timer(seconds=breakTime):
-            pub.sendMessage('updateTimer', time=elapsedTime, percent=percentage)
+            pub.sendMessage('updateTimer', time=elapsedTime,
+                            percent=percentage, mode='break')
 
         pub.sendMessage('timerDone')
         if lastCircle:
@@ -60,6 +61,7 @@ class Session:
         log.debug("Starting the focus timer...")
         self.circleNo += 1  # New circle
         for elapsedTime, percentage in Timer(seconds=self.focusTime):
-            pub.sendMessage('updateTimer', time=elapsedTime, percent=percentage)
+            pub.sendMessage('updateTimer', time=elapsedTime,
+                            percent=percentage, mode='focus')
 
         pub.sendMessage('timerDone')

--- a/src/gui/controller.py
+++ b/src/gui/controller.py
@@ -119,7 +119,8 @@ class Controller:
         - message: pubsub message sent
         """
         log.debug(f"updating timer with: {message}")
-        self.view.updateTimer(message['elapsedTime'], message['percent'])
+        self.view.updateTimer(message['elapsedTime'], message['percent'],
+                              message['mode'])
 
     def successRep(self, reply: dict):
         """Successful request, do nothing

--- a/src/gui/mainview.py
+++ b/src/gui/mainview.py
@@ -101,14 +101,15 @@ class AppFrame(wx.Frame):
         self.timerText.AcceptsFocusFromKeyboard = returnTrue
         self.timerProgress.AcceptsFocusFromKeyboard = returnTrue
 
-    def updateTimer(self, elapsedTime: str, percent: int):
+    def updateTimer(self, elapsedTime: str, percent: int, mode: str) -> None:
         """Update the status of the timer
         Change the text control and the progress bar to reflect the changes
         Parameters:
         - elapsedTime: elapsed time in string
         percent: percentage of time elapsed
+        - mode: current mode i.e. break / focus
         """
-        self.timerText.SetValue(elapsedTime)
+        self.timerText.SetValue(f"{mode.title()} - {elapsedTime}")
         self.timerProgress.SetValue(percent)
 
     def reset(self) -> None:


### PR DESCRIPTION
added mode field in pub message for update timer topic
timer text display in gui now displays mode in the form `<mode> - <elapsed time>`.
issue number: #3 