### PR TITLE
fixed stop button

### DIFF
--- a/src/engine/controller.py
+++ b/src/engine/controller.py
@@ -186,3 +186,4 @@ class Controller:
         """
         self.sessionThread = None
         self.sessionEvent.clear()
+        self.session = Session(self.sessionEvent)


### PR DESCRIPTION
Previously, stop button just stops the current timer. Now, stop button resets everything. The pomodoro session starts from begining.